### PR TITLE
Substituting the "Java EE SDK" by the Glassfish Server

### DIFF
--- a/src/main/jbake/content/intro002.adoc
+++ b/src/main/jbake/content/intro002.adoc
@@ -42,15 +42,14 @@ This tutorial is compatible with the following software:
 
 [[GCRNX]][[get-the-jakarta-ee-8-sdk]]
 
-Get the Jakarta EE 8 SDK
+Get the Glassfish Application Server
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To get the Jakarta EE 8 SDK, go to
-`http://www.oracle.com/technetwork/java/jakartaee/downloads/`. Download and
-install the SDK. The location where you install it is typically
-`glassfish5` in your home directory, but you can change this.
+To get the Glassfish, go to `https://eclipse-ee4j.github.io/glassfish/download`.
+Download and install the Glassfish. The location where you install it is typically
+`glassfish` in your home directory, but you can change this.
 
-The tutorial is installed in the `docs/firstcup` directory of your SDK
+The tutorial is installed in the `docs/firstcup` directory of your Glassfish
 installation.
 
 [[GCRNU]][[install-the-netbeans-ide-distribution-for-java-ee]]


### PR DESCRIPTION
I am reading Jakarta and First Cup and taking the opportunity to make some contributions.
This part of the tutorial refers to the "Java EE SDK" which is nothing more than a version of Glassfish with the "firstcup" project, so replace this part to refer to glassfish.
Currently, Glassfish does not accompany "firstcup" in the docs folder, so I opened the pull request eclipse-ee4j/glassfish#23125 to add it.
