### PR TITLE
Changing Java EE to Jakarta EE

### DIFF
--- a/src/main/jbake/content/jakarta-ee001.adoc
+++ b/src/main/jbake/content/jakarta-ee001.adoc
@@ -100,7 +100,7 @@ refer to Jakarta EE components
 |Servlets |Java programming language classes that dynamically process
 requests and construct responses, usually for HTML pages
 
-|Contexts and Dependency Injection for Java EE |A set of contextual
+|Contexts and Dependency Injection for Jakarta EE |A set of contextual
 services that make it easy for developers to use enterprise beans along
 with JavaServer Faces technology in web applications
 |=======================================================================


### PR DESCRIPTION
Hey guys,
Reading the documentation I observed that where "Java EE" was written now its "Jakarta EE".
So I believe that this case has gone unnoticed.